### PR TITLE
Add a new rc.conf variable "dsbdriverd_blacklist" to easier exclude

### DIFF
--- a/rc.d/dsbdriverd.tmpl
+++ b/rc.d/dsbdriverd.tmpl
@@ -12,17 +12,28 @@
 #				Set it to YES to enable dsbdriverd.
 # dsbdriverd_flags (str):	Flags passed to dsbdriverd on startup.
 #				Default is "".
-#
+# dsbdriverd_blacklist (str):	Kernel excluded from loading space separated,
+#                               without .ko extension).
+#				Default is "".
 
 . /etc/rc.subr
 
 name=dsbdriverd
-command=@PATH_PROGRAM@
+desc="automatically try to load the suitable driver for your PCI and USB hardware"
 rcvar=dsbdriverd_enable
 pidfile=@PATH_PIDFILE@
 
 load_rc_config $name
 
 : ${dsbdriverd_enable:="NO"}
+
+dsbdriverd_start() {
+	if [ -n "$dsbdriverd_blacklist" ]; then
+		dsbdriverd_blacklist="-x $(echo $dsbdriverd_blacklist |
+		    sed -e 's/[ ]+/,/g')"
+	fi
+
+	@PATH_PROGRAM@ $dsbdriverd_flags
+}
 
 run_rc_command "$1"


### PR DESCRIPTION
kernel modules from auto-loading.

(Can probably be written in a better way but this one works.)